### PR TITLE
Pin GitHub Actions to commit SHAs and scope workflow permissions

### DIFF
--- a/.github/workflows/new-post.yml
+++ b/.github/workflows/new-post.yml
@@ -6,14 +6,18 @@ jobs:
   notify-if-blog-post:
     if: github.event.pull_request.draft == false && (startsWith(github.event.pull_request.title, 'Post') || contains(github.event.pull_request.labels.*.name, 'post'))
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
-      - uses: actions/checkout@v2
-      - uses: loadsmart/github-actions/.github/actions/read-blog-post-content@master
+      - uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4.2.2
+        with:
+          persist-credentials: false
+      - uses: loadsmart/github-actions/.github/actions/read-blog-post-content@75610976c054f38ac652b01129bb26b11405b4f4 # master
         name: Read blog post content from Markdown
         id: read-blog-post-content
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-      - uses: loadsmart/github-actions/.github/actions/notify-of-new-blog-post-to-review@master
+      - uses: loadsmart/github-actions/.github/actions/notify-of-new-blog-post-to-review@75610976c054f38ac652b01129bb26b11405b4f4 # master
         name: Send Slack notification with preview of the post
         with:
           title: ${{ steps.read-blog-post-content.outputs.title }}


### PR DESCRIPTION
## Types of changes

Chore (CI security hardening)

## Description of the proposed changes

Hardens the `new-post.yml` workflow based on a `zizmor` static analysis of the repo's GitHub Actions:

- **Pin internal composite actions to a commit SHA.** `read-blog-post-content` and `notify-of-new-blog-post-to-review` were referenced via the mutable `@master` ref of `loadsmart/github-actions`. Anyone able to push to that repo's `master` (or a compromise of it) would flow straight into this workflow with the repo token. Both are now pinned to a commit SHA with a `# master` comment for readability.
- **Pin and upgrade `actions/checkout`.** Was `@v2` (unpinned + outdated); now pinned to the `v4.2.2` commit SHA, with `persist-credentials: false` so the token isn't left on disk.
- **Scope job permissions.** The `notify-if-blog-post` job ran with the default (broad) `GITHUB_TOKEN`; it only needs `contents: read`, which is now set explicitly.

After these changes `zizmor` reports no findings for this workflow.

## Screenshots

N/A — CI configuration change only.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced workflow configuration with improved security permissions and updated action versions for better maintainability and reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/loadsmart/blog/pull/79?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->